### PR TITLE
Switch to the new SettingsService

### DIFF
--- a/Win.Logic/Services/SettingsService.cs
+++ b/Win.Logic/Services/SettingsService.cs
@@ -1,10 +1,80 @@
+using Stoffi.Core.Services;
 using System;
 using Template10.Common;
 using Template10.Utils;
 using Windows.UI.Xaml;
+using Template10.Services.SettingsService;
 
-namespace Stoffi.Services
+namespace Stoffi.Win.Logic.Services
 {
+    /// <summary>
+    /// Stores settings in the Windows default setting storage by
+    /// leveraging the Template10 helper.
+    /// 
+    /// Implements three strategies for storing the settings:
+    /// - Local: Settings are stored locally on the device
+    /// - Temp: Settings are stored in temporary storage
+    /// - Roam: Settings are shared between devices
+    /// </summary>
+    public class SettingsStorage : ISettingsStorage
+    {
+        ISettingsHelper helper;
+
+        /// <summary>
+        /// The strategy to use for storing settings.
+        /// </summary>
+        public SettingsStrategies Strategy { get; set; }
+
+        public SettingsStorage(SettingsStrategies strategy = SettingsStrategies.Roam)
+        {
+            helper = new SettingsHelper();
+            Strategy = strategy;
+        }
+
+        /// <summary>
+        /// Check whether a given setting exists.
+        /// </summary>
+        /// <param name="name">The name of the record</param>
+        /// <returns>True if the setting exists, false otherwise</returns>
+        public bool Exists(string name)
+        {
+            helper.Exists(name, Strategy);
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Read the value of a given setting.
+        /// </summary>
+        /// <typeparam name="T">The type of the setting</typeparam>
+        /// <param name="name">The name of the setting</param>
+        /// <param name="otherwise">The default value to return if the setting is not found</param>
+        /// <returns>The setting if found, `otherwise` if not</returns>
+        public T Read<T>(string name, T otherwise)
+        {
+            return helper.Read<T>(name, otherwise, Strategy);
+        }
+
+        /// <summary>
+        /// Remove a given setting.
+        /// </summary>
+        /// <param name="name">The name of the setting</param>
+        public void Remove(string name)
+        {
+            helper.Remove(name, Strategy);
+        }
+
+        /// <summary>
+        /// Save a setting.
+        /// </summary>
+        /// <typeparam name="T">The type of the setting</typeparam>
+        /// <param name="name">The name of the setting</param>
+        /// <param name="value">The value of the setting</param>
+        public void Write<T>(string name, T value)
+        {
+            helper.Write<T>(name, value, Strategy);
+        }
+    }
+
     public class SettingsService
     {
         public static SettingsService Instance { get; }

--- a/Win.Logic/ViewModels/DashboardPageViewModel.cs
+++ b/Win.Logic/ViewModels/DashboardPageViewModel.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Template10.Services.NavigationService;
 using Windows.UI.Xaml.Navigation;
 
-namespace Stoffi.Win.ViewModels
+namespace Stoffi.Win.Logic.ViewModels
 {
     public class DashboardPageViewModel : ViewModelBase
     {

--- a/Win.Logic/ViewModels/MusicPageViewModel.cs
+++ b/Win.Logic/ViewModels/MusicPageViewModel.cs
@@ -10,7 +10,7 @@ using Stoffi.Core.Models;
 using Stoffi.Core.Services;
 using Windows.UI.Xaml.Controls;
 
-namespace Stoffi.Win.ViewModels
+namespace Stoffi.Win.Logic.ViewModels
 {
     /// <summary>
     /// Drives the view showing lists of songs.

--- a/Win.Logic/ViewModels/PlaylistsPageViewModel.cs
+++ b/Win.Logic/ViewModels/PlaylistsPageViewModel.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Template10.Services.NavigationService;
 using Windows.UI.Xaml.Navigation;
 
-namespace Stoffi.Win.ViewModels
+namespace Stoffi.Win.Logic.ViewModels
 {
     public class PlaylistsPageViewModel : ViewModelBase
     {

--- a/Win.Logic/ViewModels/SettingsPageViewModel.cs
+++ b/Win.Logic/ViewModels/SettingsPageViewModel.cs
@@ -1,11 +1,12 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Template10.Mvvm;
-using Template10.Services.SettingsService;
 using Windows.UI.Xaml;
+using Microsoft.Practices.Unity;
+using Stoffi.Core.Services;
+using Template10.Utils;
 
-namespace Stoffi.Win.ViewModels
+namespace Stoffi.Win.Logic.ViewModels
 {
     public class SettingsPageViewModel : ViewModelBase
     {
@@ -16,9 +17,11 @@ namespace Stoffi.Win.ViewModels
     public class SettingsPartViewModel : ViewModelBase
     {
         Services.SettingsService settings;
+        ISettingsService settings2;
 
         public SettingsPartViewModel()
         {
+            settings2 = Container.Instance.Resolve<ISettingsService>();
             if (Windows.ApplicationModel.DesignMode.DesignModeEnabled)
             {
                 // designtime
@@ -37,8 +40,20 @@ namespace Stoffi.Win.ViewModels
 
         public bool UseLightThemeButton
         {
-            get { return settings.AppTheme.Equals(ApplicationTheme.Light); }
-            set { settings.AppTheme = value ? ApplicationTheme.Light : ApplicationTheme.Dark; base.RaisePropertyChanged(); }
+            get
+            {
+                var theme = settings2.Read<ApplicationTheme>("theme", ApplicationTheme.Dark);
+                return theme.Equals(ApplicationTheme.Light);
+            }
+            set
+            {
+                ApplicationTheme theme = value ? ApplicationTheme.Light : ApplicationTheme.Dark;
+                settings2.Write<ApplicationTheme>("theme", theme);
+                (Window.Current.Content as FrameworkElement).RequestedTheme = theme.ToElementTheme();
+                base.RaisePropertyChanged();
+            }
+            //get { return settings.AppTheme.Equals(ApplicationTheme.Light); }
+            //set { settings.AppTheme = value ? ApplicationTheme.Light : ApplicationTheme.Dark; base.RaisePropertyChanged(); }
         }
 
         private string _BusyText = "Please wait...";

--- a/Win.Logic/ViewModels/SettingsPageViewModel.cs
+++ b/Win.Logic/ViewModels/SettingsPageViewModel.cs
@@ -16,44 +16,30 @@ namespace Stoffi.Win.Logic.ViewModels
 
     public class SettingsPartViewModel : ViewModelBase
     {
-        Services.SettingsService settings;
-        ISettingsService settings2;
+        ISettingsService settings;
 
         public SettingsPartViewModel()
         {
-            settings2 = Container.Instance.Resolve<ISettingsService>();
-            if (Windows.ApplicationModel.DesignMode.DesignModeEnabled)
-            {
-                // designtime
-            }
-            else
-            {
-                settings = Services.SettingsService.Instance;
-            }
+            settings = Container.Instance.Resolve<ISettingsService>();
         }
 
-        public bool UseShellBackButton
-        {
-            get { return settings.UseShellBackButton; }
-            set { settings.UseShellBackButton = value; base.RaisePropertyChanged(); }
-        }
-
+        /// <summary>
+        /// Gets or sets whether or not to use the Light theme.
+        /// </summary>
         public bool UseLightThemeButton
         {
             get
             {
-                var theme = settings2.Read<ApplicationTheme>("theme", ApplicationTheme.Dark);
+                var theme = settings.Read<ApplicationTheme>("AppTheme", ApplicationTheme.Dark).Result;
                 return theme.Equals(ApplicationTheme.Light);
             }
             set
             {
                 ApplicationTheme theme = value ? ApplicationTheme.Light : ApplicationTheme.Dark;
-                settings2.Write<ApplicationTheme>("theme", theme);
+                settings.Write<ApplicationTheme>("AppTheme", theme).Wait();
                 (Window.Current.Content as FrameworkElement).RequestedTheme = theme.ToElementTheme();
                 base.RaisePropertyChanged();
             }
-            //get { return settings.AppTheme.Equals(ApplicationTheme.Light); }
-            //set { settings.AppTheme = value ? ApplicationTheme.Light : ApplicationTheme.Dark; base.RaisePropertyChanged(); }
         }
 
         private string _BusyText = "Please wait...";

--- a/Win.Logic/ViewModels/TimelinePageViewModel.cs
+++ b/Win.Logic/ViewModels/TimelinePageViewModel.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Template10.Services.NavigationService;
 using Windows.UI.Xaml.Navigation;
 
-namespace Stoffi.Win.ViewModels
+namespace Stoffi.Win.Logic.ViewModels
 {
     public class TimelinePageViewModel : ViewModelBase
     {

--- a/Win.Logic/Win.Logic.nuget.targets
+++ b/Win.Logic/Win.Logic.nuget.targets
@@ -4,6 +4,6 @@
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
   <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)\Template10\1.1.10\build\uap10.0\Template10.targets" Condition="Exists('$(NuGetPackageRoot)\Template10\1.1.10\build\uap10.0\Template10.targets')" />
+    <Import Project="$(NuGetPackageRoot)\Template10\1.1.11\build\uap10.0\Template10.targets" Condition="Exists('$(NuGetPackageRoot)\Template10\1.1.11\build\uap10.0\Template10.targets')" />
   </ImportGroup>
 </Project>

--- a/Win.Logic/project.json
+++ b/Win.Logic/project.json
@@ -1,7 +1,8 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
-    "Template10": "1.1.10"
+    "Template10": "1.1.11",
+    "Unity": "4.0.1"
   },
   "frameworks": {
     "uap10.0": {}

--- a/Win.Logic/project.lock.json
+++ b/Win.Logic/project.lock.json
@@ -3,6 +3,14 @@
   "version": 1,
   "targets": {
     "UAP,Version=v10.0": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1808,7 +1816,7 @@
           }
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -1820,9 +1828,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-arm": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3489,7 +3518,7 @@
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -3501,9 +3530,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-arm-aot": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5128,7 +5178,7 @@
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -5140,9 +5190,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-x64": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6817,7 +6888,7 @@
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -6829,9 +6900,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-x64-aot": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8456,7 +8548,7 @@
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -8468,9 +8560,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-x86": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10145,7 +10258,7 @@
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -10157,9 +10270,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-x86-aot": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11784,7 +11918,7 @@
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -11796,10 +11930,34 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     }
   },
   "libraries": {
+    "CommonServiceLocator/1.3.0": {
+      "sha512": "fbjO0SNwbOFPdwVfyqv+B7gIJ2CVBOFPKqn1mDDECK7KER8jFaOdcvroFYoAHa0ktPbxi5s+15qOLnA96f8GSA==",
+      "type": "package",
+      "files": [
+        "CommonServiceLocator.1.3.0.nupkg.sha512",
+        "CommonServiceLocator.nuspec",
+        "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.XML",
+        "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll",
+        "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.pdb"
+      ]
+    },
     "Microsoft.CSharp/4.0.0": {
       "sha512": "oWqeKUxHXdK6dL2CFjgMcaBISbkk+AqEg+yvJHE4DElNzS4QaTsCflgkkqZwVlWby1Dg9zo9n+iCAMFefFdJ/A==",
       "type": "package",
@@ -15131,11 +15289,11 @@
         "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll"
       ]
     },
-    "Template10/1.1.10": {
-      "sha512": "RtruWmaTlD7FMHFNxY1aRcNsvkbasX6bu6wstKwSu6eaioCfFgxk9DUvgzNH5Zd/h2oGIKZT+b/Tv73tEWq6tA==",
+    "Template10/1.1.11": {
+      "sha512": "xXPtDTGpSX/QV+r37AGR8oCcUaP2f4c2XD4dHE8T9dFVwq/o51ACWJW35zpSadTsDtwtBrNBMbcOZup5rTzcYA==",
       "type": "package",
       "files": [
-        "Template10.1.1.10.nupkg.sha512",
+        "Template10.1.1.11.nupkg.sha512",
         "Template10.nuspec",
         "build/uap10.0/Template10.targets",
         "lib/uap10.0/Template10Library.dll",
@@ -15149,12 +15307,39 @@
         "lib/uap10.0/Template10Library/Themes/PageHeader.xaml",
         "lib/uap10.0/Template10Library/Themes/Resizer.xaml"
       ]
+    },
+    "Unity/4.0.1": {
+      "sha512": "RHFTCW13E186hCI0Z4R47tl2SyxQOp3TNaBlilxKktO+u+NUWyOK/nPJ25PWwgPh4j4/GM46PQszSsusui+ikw==",
+      "type": "package",
+      "files": [
+        "Unity.4.0.1.nupkg.sha512",
+        "Unity.nuspec",
+        "UnityConfiguration30.xsd",
+        "lib/net45/Microsoft.Practices.Unity.Configuration.XML",
+        "lib/net45/Microsoft.Practices.Unity.Configuration.dll",
+        "lib/net45/Microsoft.Practices.Unity.RegistrationByConvention.XML",
+        "lib/net45/Microsoft.Practices.Unity.RegistrationByConvention.dll",
+        "lib/net45/Microsoft.Practices.Unity.dll",
+        "lib/net45/Microsoft.Practices.Unity.xml",
+        "lib/portable-net45+wp80+win8+wpa81+MonoAndroid10+MonoTouch10/Microsoft.Practices.Unity.dll",
+        "lib/portable-net45+wp80+win8+wpa81+MonoAndroid10+MonoTouch10/Microsoft.Practices.Unity.xml",
+        "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.XML",
+        "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll",
+        "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.pri",
+        "lib/win8/Microsoft.Practices.Unity.dll",
+        "lib/win8/Microsoft.Practices.Unity.xml",
+        "lib/wp80/Microsoft.Practices.Unity.RegistrationByConvention.XML",
+        "lib/wp80/Microsoft.Practices.Unity.RegistrationByConvention.dll",
+        "lib/wp80/Microsoft.Practices.Unity.dll",
+        "lib/wp80/Microsoft.Practices.Unity.xml"
+      ]
     }
   },
   "projectFileDependencyGroups": {
     "": [
       "Microsoft.NETCore.UniversalWindowsPlatform >= 5.1.0",
-      "Template10 >= 1.1.10"
+      "Template10 >= 1.1.11",
+      "Unity >= 4.0.1"
     ],
     "UAP,Version=v10.0": []
   }

--- a/Win.Tests.Unit/ViewModels/MusicPageViewModelTest.cs
+++ b/Win.Tests.Unit/ViewModels/MusicPageViewModelTest.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Stoffi.Core.Models;
 using System.Threading.Tasks;
-using Stoffi.Win.ViewModels;
+using Stoffi.Win.Logic.ViewModels;
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 using Stoffi.Win.Tests.Unit.Mocks;
 using System;

--- a/Win.Tests.Unit/project.lock.json
+++ b/Win.Tests.Unit/project.lock.json
@@ -3,6 +3,14 @@
   "version": 1,
   "targets": {
     "UAP,Version=v10.0": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1808,7 +1816,7 @@
           }
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -1820,9 +1828,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-arm": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3489,7 +3518,7 @@
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -3501,9 +3530,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-arm-aot": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5128,7 +5178,7 @@
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -5140,9 +5190,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-x64": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6817,7 +6888,7 @@
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -6829,9 +6900,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-x64-aot": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8456,7 +8548,7 @@
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -8468,9 +8560,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-x86": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10145,7 +10258,7 @@
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -10157,9 +10270,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-x86-aot": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "Microsoft.CSharp/4.0.0": {
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11784,7 +11918,7 @@
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -11796,10 +11930,34 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     }
   },
   "libraries": {
+    "CommonServiceLocator/1.3.0": {
+      "sha512": "fbjO0SNwbOFPdwVfyqv+B7gIJ2CVBOFPKqn1mDDECK7KER8jFaOdcvroFYoAHa0ktPbxi5s+15qOLnA96f8GSA==",
+      "type": "package",
+      "files": [
+        "CommonServiceLocator.1.3.0.nupkg.sha512",
+        "CommonServiceLocator.nuspec",
+        "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.XML",
+        "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll",
+        "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.pdb"
+      ]
+    },
     "Microsoft.CSharp/4.0.0": {
       "sha512": "oWqeKUxHXdK6dL2CFjgMcaBISbkk+AqEg+yvJHE4DElNzS4QaTsCflgkkqZwVlWby1Dg9zo9n+iCAMFefFdJ/A==",
       "type": "package",
@@ -15131,11 +15289,11 @@
         "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll"
       ]
     },
-    "Template10/1.1.10": {
-      "sha512": "RtruWmaTlD7FMHFNxY1aRcNsvkbasX6bu6wstKwSu6eaioCfFgxk9DUvgzNH5Zd/h2oGIKZT+b/Tv73tEWq6tA==",
+    "Template10/1.1.11": {
+      "sha512": "xXPtDTGpSX/QV+r37AGR8oCcUaP2f4c2XD4dHE8T9dFVwq/o51ACWJW35zpSadTsDtwtBrNBMbcOZup5rTzcYA==",
       "type": "package",
       "files": [
-        "Template10.1.1.10.nupkg.sha512",
+        "Template10.1.1.11.nupkg.sha512",
         "Template10.nuspec",
         "build/uap10.0/Template10.targets",
         "lib/uap10.0/Template10Library.dll",
@@ -15148,6 +15306,32 @@
         "lib/uap10.0/Template10Library/Themes/ModalDialog.xaml",
         "lib/uap10.0/Template10Library/Themes/PageHeader.xaml",
         "lib/uap10.0/Template10Library/Themes/Resizer.xaml"
+      ]
+    },
+    "Unity/4.0.1": {
+      "sha512": "RHFTCW13E186hCI0Z4R47tl2SyxQOp3TNaBlilxKktO+u+NUWyOK/nPJ25PWwgPh4j4/GM46PQszSsusui+ikw==",
+      "type": "package",
+      "files": [
+        "Unity.4.0.1.nupkg.sha512",
+        "Unity.nuspec",
+        "UnityConfiguration30.xsd",
+        "lib/net45/Microsoft.Practices.Unity.Configuration.XML",
+        "lib/net45/Microsoft.Practices.Unity.Configuration.dll",
+        "lib/net45/Microsoft.Practices.Unity.RegistrationByConvention.XML",
+        "lib/net45/Microsoft.Practices.Unity.RegistrationByConvention.dll",
+        "lib/net45/Microsoft.Practices.Unity.dll",
+        "lib/net45/Microsoft.Practices.Unity.xml",
+        "lib/portable-net45+wp80+win8+wpa81+MonoAndroid10+MonoTouch10/Microsoft.Practices.Unity.dll",
+        "lib/portable-net45+wp80+win8+wpa81+MonoAndroid10+MonoTouch10/Microsoft.Practices.Unity.xml",
+        "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.XML",
+        "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll",
+        "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.pri",
+        "lib/win8/Microsoft.Practices.Unity.dll",
+        "lib/win8/Microsoft.Practices.Unity.xml",
+        "lib/wp80/Microsoft.Practices.Unity.RegistrationByConvention.XML",
+        "lib/wp80/Microsoft.Practices.Unity.RegistrationByConvention.dll",
+        "lib/wp80/Microsoft.Practices.Unity.dll",
+        "lib/wp80/Microsoft.Practices.Unity.xml"
       ]
     }
   },

--- a/Win.UI/App.xaml
+++ b/Win.UI/App.xaml
@@ -1,9 +1,11 @@
-<common:BootStrapper
-                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<common:BootStrapper xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                      xmlns:common="using:Template10.Common"
-                     xmlns:ViewModels="using:Stoffi.Win.ViewModels" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d" x:Class="Stoffi.Win.App"
-                     RequestedTheme="Dark">
+                     xmlns:ViewModels="using:Stoffi.Win.ViewModels"
+                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+                     mc:Ignorable="d"
+                     x:Class="Stoffi.Win.App">
 
     <common:BootStrapper.Resources>
         <ResourceDictionary Source="Styles\Custom.xaml" >

--- a/Win.UI/App.xaml.cs
+++ b/Win.UI/App.xaml.cs
@@ -4,9 +4,9 @@ using Stoffi.Win.Logic.Services;
 using Windows.ApplicationModel.Activation;
 using Template10.Controls;
 using Template10.Common;
-using Template10.Utils;
 using Microsoft.Practices.Unity;
 using Stoffi.Core.Services;
+using Windows.ApplicationModel;
 
 namespace Stoffi.Win
 {
@@ -19,16 +19,19 @@ namespace Stoffi.Win
         {
             InitializeComponent();
             SplashFactory = (e) => new Views.Splash(e);
+            EnableAutoRestoreAfterTerminated = false;
 
             #region IoC
-            Container.Instance.RegisterInstance<SettingsStorage>(new SettingsStorage());
+            var settingsStorage = new SettingsStorage();
+            settingsStorage.LargeSettings.Add("NavigationState");
+            Container.Instance.RegisterInstance<SettingsStorage>(settingsStorage);
             Container.Instance.RegisterType<ISettingsStorage, SettingsStorage>();
             Container.Instance.RegisterType<ISettingsService, Core.Services.SettingsService>();
             #endregion
 
             #region App settings
             var settings = Container.Instance.Resolve<ISettingsService>();
-            var theme = settings.Read<ApplicationTheme>("theme", ApplicationTheme.Dark);
+            var theme = settings.Read<ApplicationTheme>("AppTheme", ApplicationTheme.Dark).Result;
             RequestedTheme = theme;
             #endregion
         }
@@ -52,10 +55,23 @@ namespace Stoffi.Win
 
         public override async Task OnStartAsync(StartKind startKind, IActivatedEventArgs args)
         {
-            // long-running startup tasks go here
-
-            NavigationService.Navigate(typeof(Views.DashboardPage));
+            if (startKind == StartKind.Launch)
+            {
+                var settings = Container.Instance.Resolve<ISettingsService>();
+                var navState = await settings.Read<string>("NavigationState", "");
+                if (string.IsNullOrWhiteSpace(navState))
+                    NavigationService.Navigate(typeof(Views.DashboardPage));
+                else
+                    NavigationService.NavigationState = navState;
+            }
             await Task.CompletedTask;
+        }
+
+        public override Task OnSuspendingAsync(object s, SuspendingEventArgs e, bool prelaunchActivated)
+        {
+            var settings = Container.Instance.Resolve<ISettingsService>();
+            settings.Write<string>("NavigationState", NavigationService.NavigationState);
+            return base.OnSuspendingAsync(s, e, prelaunchActivated);
         }
     }
 }

--- a/Win.UI/App.xaml.cs
+++ b/Win.UI/App.xaml.cs
@@ -1,31 +1,35 @@
 using Windows.UI.Xaml;
 using System.Threading.Tasks;
-using Stoffi.Services;
+using Stoffi.Win.Logic.Services;
 using Windows.ApplicationModel.Activation;
 using Template10.Controls;
 using Template10.Common;
-using System;
-using System.Linq;
+using Template10.Utils;
+using Microsoft.Practices.Unity;
+using Stoffi.Core.Services;
 
 namespace Stoffi.Win
 {
     /// Documentation on APIs used in this page:
     /// https://github.com/Windows-XAML/Template10/wiki
 
-    sealed partial class App : Template10.Common.BootStrapper
+    sealed partial class App : BootStrapper
     {
         public App()
         {
             InitializeComponent();
             SplashFactory = (e) => new Views.Splash(e);
 
+            #region IoC
+            Container.Instance.RegisterInstance<SettingsStorage>(new SettingsStorage());
+            Container.Instance.RegisterType<ISettingsStorage, SettingsStorage>();
+            Container.Instance.RegisterType<ISettingsService, Core.Services.SettingsService>();
+            #endregion
+
             #region App settings
-
-            var settings = SettingsService.Instance;
-            RequestedTheme = settings.AppTheme;
-            CacheMaxDuration = settings.CacheMaxDuration;
-            ShowShellBackButton = settings.UseShellBackButton;
-
+            var settings = Container.Instance.Resolve<ISettingsService>();
+            var theme = settings.Read<ApplicationTheme>("theme", ApplicationTheme.Dark);
+            RequestedTheme = theme;
             #endregion
         }
 

--- a/Win.UI/Views/DashboardPage.xaml
+++ b/Win.UI/Views/DashboardPage.xaml
@@ -8,7 +8,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:local="using:Stoffi.Win.Views"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:vm="using:Stoffi.Win.ViewModels" mc:Ignorable="d">
+      xmlns:vm="using:Stoffi.Win.Logic.ViewModels" mc:Ignorable="d">
 
     <Page.DataContext>
         <vm:DashboardPageViewModel x:Name="ViewModel" />

--- a/Win.UI/Views/MusicPage.xaml
+++ b/Win.UI/Views/MusicPage.xaml
@@ -10,7 +10,7 @@
       xmlns:local="using:Stoffi.Win.Views"
       xmlns:m="using:Stoffi.Core.Models"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:vm="using:Stoffi.Win.ViewModels" 
+      xmlns:vm="using:Stoffi.Win.Logic.ViewModels" 
       mc:Ignorable="d" 
       xmlns:fa="using:FontAwesome.UWP"
       Margin="0,48,0,0"

--- a/Win.UI/Views/PlaylistsPage.xaml
+++ b/Win.UI/Views/PlaylistsPage.xaml
@@ -8,7 +8,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:local="using:Stoffi.Win.Views"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:vm="using:Stoffi.Win.ViewModels" mc:Ignorable="d">
+      xmlns:vm="using:Stoffi.Win.Logic.ViewModels" mc:Ignorable="d">
 
     <Page.DataContext>
         <vm:PlaylistsPageViewModel x:Name="ViewModel" />

--- a/Win.UI/Views/SettingsPage.xaml
+++ b/Win.UI/Views/SettingsPage.xaml
@@ -4,12 +4,11 @@
       xmlns:Behaviors="using:Template10.Behaviors"
       xmlns:Core="using:Microsoft.Xaml.Interactions.Core"
       xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
-      xmlns:c="using:Stoffi.Converters"
       xmlns:controls="using:Template10.Controls"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:local="using:Stoffi.Win.Views"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:vm="using:Stoffi.Win.ViewModels" mc:Ignorable="d">
+      xmlns:vm="using:Stoffi.Win.Logic.ViewModels" mc:Ignorable="d">
 
     <Page.DataContext>
         <vm:SettingsPageViewModel x:Name="ViewModel" />

--- a/Win.UI/Views/TimelinePage.xaml
+++ b/Win.UI/Views/TimelinePage.xaml
@@ -8,7 +8,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:local="using:Stoffi.Win.Views"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-      xmlns:vm="using:Stoffi.Win.ViewModels" mc:Ignorable="d">
+      xmlns:vm="using:Stoffi.Win.Logic.ViewModels" mc:Ignorable="d">
 
     <Page.DataContext>
         <vm:TimelinePageViewModel x:Name="ViewModel" />

--- a/Win.UI/Win.UI.csproj
+++ b/Win.UI/Win.UI.csproj
@@ -206,7 +206,7 @@
   <ItemGroup />
   <ItemGroup>
     <ProjectReference Include="..\Core\Core\Core.csproj">
-      <Project>{34D34064-25B3-49D1-9879-AF3076FB3A26}</Project>
+      <Project>{34d34064-25b3-49d1-9879-af3076fb3a26}</Project>
       <Name>Core</Name>
     </ProjectReference>
     <ProjectReference Include="..\Win.Logic\Win.Logic.csproj">

--- a/Win.UI/Win.UI.nuget.targets
+++ b/Win.UI/Win.UI.nuget.targets
@@ -4,6 +4,6 @@
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
   <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)\Template10\1.1.10\build\uap10.0\Template10.targets" Condition="Exists('$(NuGetPackageRoot)\Template10\1.1.10\build\uap10.0\Template10.targets')" />
+    <Import Project="$(NuGetPackageRoot)\Template10\1.1.11\build\uap10.0\Template10.targets" Condition="Exists('$(NuGetPackageRoot)\Template10\1.1.11\build\uap10.0\Template10.targets')" />
   </ImportGroup>
 </Project>

--- a/Win.UI/project.json
+++ b/Win.UI/project.json
@@ -4,7 +4,8 @@
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
     "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
     "Newtonsoft.Json": "8.0.3",
-    "Template10": "1.1.10"
+    "Template10": "1.1.11",
+    "Unity": "4.0.1"
   },
   "frameworks": {
     "uap10.0": {}

--- a/Win.UI/project.lock.json
+++ b/Win.UI/project.lock.json
@@ -3,6 +3,14 @@
   "version": 1,
   "targets": {
     "UAP,Version=v10.0": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "FontAwesome.UWP/4.5.0.8": {
         "compile": {
           "lib/uap10.0/FontAwesome.UWP.dll": {}
@@ -1816,7 +1824,7 @@
           }
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -1828,9 +1836,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-arm": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "FontAwesome.UWP/4.5.0.8": {
         "compile": {
           "lib/uap10.0/FontAwesome.UWP.dll": {}
@@ -3505,7 +3534,7 @@
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -3517,9 +3546,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-arm-aot": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "FontAwesome.UWP/4.5.0.8": {
         "compile": {
           "lib/uap10.0/FontAwesome.UWP.dll": {}
@@ -5152,7 +5202,7 @@
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -5164,9 +5214,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-x64": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "FontAwesome.UWP/4.5.0.8": {
         "compile": {
           "lib/uap10.0/FontAwesome.UWP.dll": {}
@@ -6849,7 +6920,7 @@
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -6861,9 +6932,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-x64-aot": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "FontAwesome.UWP/4.5.0.8": {
         "compile": {
           "lib/uap10.0/FontAwesome.UWP.dll": {}
@@ -8496,7 +8588,7 @@
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -8508,9 +8600,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-x86": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "FontAwesome.UWP/4.5.0.8": {
         "compile": {
           "lib/uap10.0/FontAwesome.UWP.dll": {}
@@ -10193,7 +10306,7 @@
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -10205,9 +10318,30 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     },
     "UAP,Version=v10.0/win10-x86-aot": {
+      "CommonServiceLocator/1.3.0": {
+        "compile": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll": {}
+        }
+      },
       "FontAwesome.UWP/4.5.0.8": {
         "compile": {
           "lib/uap10.0/FontAwesome.UWP.dll": {}
@@ -11840,7 +11974,7 @@
           "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "Template10/1.1.10": {
+      "Template10/1.1.11": {
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
           "Microsoft.Xaml.Behaviors.Uwp.Managed": "1.1.0",
@@ -11852,10 +11986,34 @@
         "runtime": {
           "lib/uap10.0/Template10Library.dll": {}
         }
+      },
+      "Unity/4.0.1": {
+        "dependencies": {
+          "CommonServiceLocator": "1.3.0"
+        },
+        "compile": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        },
+        "runtime": {
+          "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll": {},
+          "lib/win8/Microsoft.Practices.Unity.dll": {}
+        }
       }
     }
   },
   "libraries": {
+    "CommonServiceLocator/1.3.0": {
+      "sha512": "fbjO0SNwbOFPdwVfyqv+B7gIJ2CVBOFPKqn1mDDECK7KER8jFaOdcvroFYoAHa0ktPbxi5s+15qOLnA96f8GSA==",
+      "type": "package",
+      "files": [
+        "CommonServiceLocator.1.3.0.nupkg.sha512",
+        "CommonServiceLocator.nuspec",
+        "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.XML",
+        "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.dll",
+        "lib/portable-net4+sl5+netcore45+wpa81+wp8/Microsoft.Practices.ServiceLocation.pdb"
+      ]
+    },
     "FontAwesome.UWP/4.5.0.8": {
       "sha512": "HVoUY9gvrYRMxiyt+UyM8fM1SagiXVjmfyXYWCbcXwx4ydugGukf2fOoEXXfaFU4Se9TPNLTD4cp4FEHLXq6og==",
       "type": "Package",
@@ -15402,11 +15560,11 @@
         "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll"
       ]
     },
-    "Template10/1.1.10": {
-      "sha512": "RtruWmaTlD7FMHFNxY1aRcNsvkbasX6bu6wstKwSu6eaioCfFgxk9DUvgzNH5Zd/h2oGIKZT+b/Tv73tEWq6tA==",
+    "Template10/1.1.11": {
+      "sha512": "xXPtDTGpSX/QV+r37AGR8oCcUaP2f4c2XD4dHE8T9dFVwq/o51ACWJW35zpSadTsDtwtBrNBMbcOZup5rTzcYA==",
       "type": "package",
       "files": [
-        "Template10.1.1.10.nupkg.sha512",
+        "Template10.1.1.11.nupkg.sha512",
         "Template10.nuspec",
         "build/uap10.0/Template10.targets",
         "lib/uap10.0/Template10Library.dll",
@@ -15420,6 +15578,32 @@
         "lib/uap10.0/Template10Library/Themes/PageHeader.xaml",
         "lib/uap10.0/Template10Library/Themes/Resizer.xaml"
       ]
+    },
+    "Unity/4.0.1": {
+      "sha512": "RHFTCW13E186hCI0Z4R47tl2SyxQOp3TNaBlilxKktO+u+NUWyOK/nPJ25PWwgPh4j4/GM46PQszSsusui+ikw==",
+      "type": "package",
+      "files": [
+        "Unity.4.0.1.nupkg.sha512",
+        "Unity.nuspec",
+        "UnityConfiguration30.xsd",
+        "lib/net45/Microsoft.Practices.Unity.Configuration.XML",
+        "lib/net45/Microsoft.Practices.Unity.Configuration.dll",
+        "lib/net45/Microsoft.Practices.Unity.RegistrationByConvention.XML",
+        "lib/net45/Microsoft.Practices.Unity.RegistrationByConvention.dll",
+        "lib/net45/Microsoft.Practices.Unity.dll",
+        "lib/net45/Microsoft.Practices.Unity.xml",
+        "lib/portable-net45+wp80+win8+wpa81+MonoAndroid10+MonoTouch10/Microsoft.Practices.Unity.dll",
+        "lib/portable-net45+wp80+win8+wpa81+MonoAndroid10+MonoTouch10/Microsoft.Practices.Unity.xml",
+        "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.XML",
+        "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.dll",
+        "lib/win8/Microsoft.Practices.Unity.RegistrationByConvention.pri",
+        "lib/win8/Microsoft.Practices.Unity.dll",
+        "lib/win8/Microsoft.Practices.Unity.xml",
+        "lib/wp80/Microsoft.Practices.Unity.RegistrationByConvention.XML",
+        "lib/wp80/Microsoft.Practices.Unity.RegistrationByConvention.dll",
+        "lib/wp80/Microsoft.Practices.Unity.dll",
+        "lib/wp80/Microsoft.Practices.Unity.xml"
+      ]
     }
   },
   "projectFileDependencyGroups": {
@@ -15428,7 +15612,8 @@
       "Microsoft.NETCore.UniversalWindowsPlatform >= 5.1.0",
       "Microsoft.Xaml.Behaviors.Uwp.Managed >= 1.1.0",
       "Newtonsoft.Json >= 8.0.3",
-      "Template10 >= 1.1.10"
+      "Template10 >= 1.1.11",
+      "Unity >= 4.0.1"
     ],
     "UAP,Version=v10.0": []
   }


### PR DESCRIPTION
Update Core submodule and use the new `ISettingsService`. Implement a storage driver for the service that stores settings in the default UWP settings storage (using the helper classes from Template10), with defaulting to the user's roaming profile.

Since UWP imposes a 6k limit on the settings, the storage driver allows specified settings to be stored in file instead, which enables larger settings to be managed by the same service interface.

The app setting for the theme is moved into the new service. The navigation state is also stored in the settings service, marked as potentially large, effectively putting it into a file instead.